### PR TITLE
Made compatible with gradle-groovy-android-plugin v1.0.0

### DIFF
--- a/src/main/groovy/net/kaleidos/gradle/plugins/emerger/EmergerPlugin.groovy
+++ b/src/main/groovy/net/kaleidos/gradle/plugins/emerger/EmergerPlugin.groovy
@@ -21,6 +21,8 @@ class EmergerPlugin implements Plugin<Project> {
     @SuppressWarnings('NoDef')
     void apply(final Project project) {
         Plugin<Project> groovyAndroidPlugin = project.plugins.findPlugin('groovyx.grooid.groovy-android')
+        if (!groovyAndroidPlugin)
+            groovyAndroidPlugin = project.plugins.findPlugin('groovyx.android')
 
         /* It only makes sense along with the Groovy/Android plugin */
         if (!groovyAndroidPlugin) {


### PR DESCRIPTION
In gradle-groovy-android-plugin 1.0.0 plugin name was changed from `groovyx.grooid.groovy-android` to `groovyx.android`, so emerger shouldn't panic if it sees 
`apply plugin: 'groovyx.android'` instead of `apply plugin: 'groovyx.grooid.groovy-android'`
